### PR TITLE
v1.0.1

### DIFF
--- a/904_GEM_LV/904_GEM_LV.xml
+++ b/904_GEM_LV/904_GEM_LV.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <component>
   <name>904_GEM_LV</name>
-  <version>1.0.0</version>
-  <date>20/02/2018</date>
+  <version>1.0.1</version>
+  <date>21/02/2018</date>
   <required>fwCaen=8.0.0</required>
   <required>fwCore=8.0.6</required>
   <required>fwTrending=8.0.0</required>

--- a/904_GEM_LV/904_GEM_LV_config.xml
+++ b/904_GEM_LV/904_GEM_LV_config.xml
@@ -27,18 +27,18 @@
   <target>
     <system_name>cms_gem_dcs_1:</system_name>
     <configuration>
-      <tag>904_LV_dp_V000</tag>
+      <tag>904_LV_dp_V001</tag>
       <hardware>true</hardware>
       <logical>false</logical>
       <pattern>*</pattern>
-      <force_reinstall>true</force_reinstall>
+      <force_reinstall>false</force_reinstall>
     </configuration>
     <configuration>
       <tag>904_LV_trending_V000</tag>
       <hardware>true</hardware>
       <logical>false</logical>
       <pattern>*</pattern>
-      <force_reinstall>true</force_reinstall>
+      <force_reinstall>false</force_reinstall>
     </configuration>
   </target>
 </component_configuration>

--- a/904_GEM_LV/panels/904_GEM_LV/904_GEM_LV_Overview.pnl
+++ b/904_GEM_LV/panels/904_GEM_LV/904_GEM_LV_Overview.pnl
@@ -4329,7 +4329,7 @@ LANG:1 35 MS Shell Dlg 2,-1,16,5,50,0,0,0,0,0
 T 
 1
 LANG:1 33 Fast LV settings
-to ALL detectors
+to ALL detector
 "// SimpleCtrlScriptStart {valid}
 main()
 {
@@ -4374,7 +4374,7 @@ LANG:1 35 MS Shell Dlg 2,-1,16,5,50,0,0,0,0,0
 T 
 1
 LANG:1 3 MAO
-"// SimpleCtrlScriptStart {valid}
+"// SimpleCtrlScriptStart {invalid}
 main()
 {
   EP_childPanelOn();
@@ -4384,7 +4384,7 @@ void EP_childPanelOn()
 {
   ChildPanelOnCentralModal(\"904_GEM_LV/fwCaenChannelOperationGEM.pnl\",
       \"\",
-      makeDynString(\"$sDpName:CAEN/904_Shared_mainframe/branchController00/easyCrate0/powerConverter20/channel000\"));
+      makeDynString(\"$sDpName:CAEN/904_Shared_mainframe/branchController00/easyCrate0/powerConverter22/channel000\"));
 }
 
 // SimpleCtrlScript {EP_childPanelOn}


### PR DESCRIPTION
904_GEM_LV updated for two reasons:
- previous version was not actually able to talk with the mainframe, I suspect this was due to wrong address settings. Now it is fixed
- it contains *only* the LV boards actually present in the system (2)